### PR TITLE
Update to upstream Ardour 6.2

### DIFF
--- a/org.ardour.Ardour.json
+++ b/org.ardour.Ardour.json
@@ -244,7 +244,8 @@
         {
           "type": "git",
           "url": "git://github.com/Ardour/ardour.git",
-          "tag": "6.0"
+          "tag": "6.2",
+          "commit": "c8e92338fffa92e4ee0bc03ca8ca9ff93ed8b2b4"
         },
         {
           "type": "patch",


### PR DESCRIPTION
Release has been tagged.

Will merge when it's out on upstream side.