### PR TITLE
Switch to freedesktop.org SDK 21.08

### DIFF
--- a/gtkmm2.json
+++ b/gtkmm2.json
@@ -7,6 +7,9 @@
             "cleanup": [
                 "/include"
             ],
+            "build-options": {
+                "cxxflags": "-std=gnu++14"
+            },
             "config-opts" : [
                 "--disable-documentation"
             ],
@@ -21,6 +24,9 @@
         },
         {
             "name": "cairomm",
+            "build-options": {
+                "cxxflags": "-std=gnu++14"
+            },
             "config-opts" : [
                 "--disable-documentation"
             ],
@@ -40,6 +46,9 @@
         },
         {
             "name": "glibmm",
+            "build-options": {
+                "cxxflags": "-std=gnu++14"
+            },
             "config-opts" : [
                 "--disable-documentation"
             ],
@@ -68,6 +77,9 @@
             "cleanup": [
                 "/include"
             ],
+            "build-options": {
+                "cxxflags": "-std=gnu++14"
+            },
             "config-opts" : [
                 "--disable-documentation"
             ],
@@ -82,6 +94,9 @@
         },
         {
             "name": "atkmm",
+            "build-options": {
+                "cxxflags": "-std=gnu++14"
+            },
             "config-opts": [
                 "--disable-documentation"
             ],
@@ -106,6 +121,9 @@
         "/lib/gdkmm-2.4",
         "*.la"
     ],
+    "build-options": {
+        "cxxflags": "-std=gnu++14"
+    },
     "config-opts" : [
         "--disable-documentation"
     ],

--- a/org.ardour.Ardour.json
+++ b/org.ardour.Ardour.json
@@ -2,7 +2,7 @@
   "app-id": "org.ardour.Ardour",
   "sdk": "org.freedesktop.Sdk",
   "runtime": "org.freedesktop.Platform",
-  "runtime-version": "20.08",
+  "runtime-version": "21.08",
   "command": "ardour6",
   "finish-args": [
     /* X11 + XShm access */
@@ -32,7 +32,7 @@
   "add-extensions": {
     "org.freedesktop.LinuxAudio.Plugins": {
       "directory": "extensions/Plugins",
-      "version": "20.08",
+      "version": "21.08",
       "add-ld-path": "lib",
       "merge-dirs": "ladspa;lv2;lxvst;vst3",
       "subdirectories": true,

--- a/org.ardour.Ardour.json
+++ b/org.ardour.Ardour.json
@@ -543,6 +543,9 @@
     {
       "name": "ardour",
       "buildsystem": "simple",
+      "build-options": {
+          "cxxflags": "-std=gnu++14"
+      },
       "build-commands": [
         "python3 ./waf configure --prefix=/app --optimize --dist-target=$FLATPAK_ARCH --debug-symbols --no-phone-home --freedesktop --with-backends=alsa,dummy,pulseaudio,jack",
         "python3 ./waf build -j $FLATPAK_BUILDER_N_JOBS",


### PR DESCRIPTION
Working on Fedora Silverblue 34 which uses pipewire, I got annoyed by #24 which makes Ardour's export unusable using the JACK backend, since pipewire is stuck at too-old version in the 20.08 freedesktop.org runtime.

Thus, I tried to build the Ardour flatpak using FDO 21.08, which brings back JACK-backend-powered export back to life, thanks to a more recent pipewire version.

I had to work-around quite a lot C++ deprecations (mainly caused by glibmm2) turned into hard errors by GCC 11 (defaulting to `gnu++17`) by using `-std=gnu++14` in the glibmm-based modules. I don't know, if this is acceptable, but maybe this is at least a start to get Ardour run on FDO 21.08?

If applied, this
Fixes #24 