### PR TITLE
allow loading vst3 plugins from home

### DIFF
--- a/org.ardour.Ardour.json
+++ b/org.ardour.Ardour.json
@@ -26,7 +26,7 @@
     /* extensions LV2 */
     "--env=LV2_PATH=$HOME/.lv2:/app/extensions/Plugins/lv2",
     "--env=LXVST_PATH=/app/extensions/Plugins/lxvst",
-    "--env=VST3_PATH=/app/extensions/Plugins/vst3",
+    "--env=VST3_PATH=$HOME/.vst3:/app/extensions/Plugins/vst3",
     "--env=LADSPA_PATH=/app/extensions/Plugins/ladspa"
   ],
   "add-extensions": {


### PR DESCRIPTION
This makes it easier to install (proprietary) vst3 plugins which are not packaged on flathub.