### PR TITLE
Add libsndfile as the one in the runtime desn't support flac or vorbis

### DIFF
--- a/org.ardour.Ardour.json
+++ b/org.ardour.Ardour.json
@@ -67,7 +67,8 @@
       "cleanup": [
         "/include",
         "/share/man",
-        "/lib/pkgconfig"
+        "/lib/pkgconfig",
+        "*.a"
       ],
       "modules": [
         {
@@ -158,6 +159,20 @@
       ]
     },
     {
+      "name": "sndfile",
+      "cleanup": [
+        ".a"
+      ],
+      "sources": [
+        {
+          /* Ardour - also 22.08 version is broken */
+          "type": "archive",
+          "url": "http://www.mega-nerd.com/libsndfile/files/libsndfile-1.0.27.tar.gz",
+          "sha256": "a391952f27f4a92ceb2b4c06493ac107896ed6c76be9a613a4731f076d30fac0"
+        }
+      ]
+    },
+    {
       "name": "taglib",
       "buildsystem": "cmake-ninja",
       "config-opts": [
@@ -194,7 +209,8 @@
       "cleanup": [
         "/bin",
         "/include",
-        "/lib/pkgconfig"
+        "/lib/pkgconfig",
+        "*.a"
       ]
     },
     {
@@ -546,6 +562,9 @@
         "python3 ./waf build -j $FLATPAK_BUILDER_N_JOBS",
         "python3 ./waf i18n -j $FLATPAK_BUILDER_N_JOBS",
         "python3 ./waf install"
+      ],
+      "cleanup": [
+        "*.a"
       ],
       "post-install": [
         "desktop-file-edit --set-key=Name --set-value=\"Ardour 6\" --set-generic-name=\"Digital Audio Workstation\" --set-key=X-GNOME-FullName --set-value=\"Ardour v6 (Digital Audio Workstation)\" --set-comment=\"Record, mix and master audio\" --remove-category=AudioEditing --add-category=X-AudioEditing --set-icon=${FLATPAK_ID} build/gtk2_ardour/ardour6.desktop",


### PR DESCRIPTION
- it's a regression in 22.08