### PR TITLE
Update to Ardour 7.3

### DIFF
--- a/gtkmm2.json
+++ b/gtkmm2.json
@@ -3,6 +3,22 @@
     "modules": [
         "gtk2.json",
         {
+            "name": "gtk-engines",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "http://ardour.org/files/gtk-engines-2.21.0.tar.gz",
+                    "sha256": "13be8ffe78502922da8988c9d00babc213d6dddb9b46f0055bd90190f468fa35"
+                },
+                {
+                    "type": "shell",
+                    "commands": [
+                        "cp -p /usr/share/automake-*/config.{sub,guess} ."
+                    ]
+                }
+            ]
+        },
+        {
             "name": "sigc++-2",
             "cleanup": [
                 "/include",

--- a/org.ardour.Ardour.json
+++ b/org.ardour.Ardour.json
@@ -585,8 +585,8 @@
         {
           "type": "git",
           "url": "https://github.com/Ardour/ardour.git",
-          "tag": "7.2",
-          "commit": "618755649832c36e0afd3a4947ff085e2e3fb1ea"
+          "tag": "7.3",
+          "commit": "8f248bd0bac70f0b7a84013ada536bdef1bbcb59"
         },
         {
           "type": "file",


### PR DESCRIPTION
- add missing gtk-engine