### PR TITLE
Make PipeWire socket read-only

### DIFF
--- a/org.ardour.Ardour.json
+++ b/org.ardour.Ardour.json
@@ -20,7 +20,7 @@
     "--share=network",
     "--env=ALSA_CONFIG_PATH=",
     "--own-name=org.freedesktop.ReserveDevice1.*",
-    "--filesystem=xdg-run/pipewire-0",
+    "--filesystem=xdg-run/pipewire-0:ro",
     "--env=TMPDIR=/var/tmp",
     "--env=LXVST_PATH=/app/extensions/Plugins/vst",
     "--env=VST3_PATH=/app/extensions/Plugins/vst3",


### PR DESCRIPTION
Flatpaks should not have write access to socket files, like `xdg-run/pipewire-0`. Bidirectional communication is possible regardless of the suffix, so a benevolent app sees no difference. While it shouldn't be possible in theory, it would be best to prevent the possibility of deleting or modifying the socket itself. Flathub maintainers typically request this for new submissions.

https://discourse.flathub.org/t/what-is-the-difference-if-the-pipewire-socket-is-read-only/11951/7